### PR TITLE
Tc/rev 74/verify bucket existence

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Photo contest API is an API for the Runtime Revolution photo contest that takes 
 
 ## Setup Time
 
-### Prerequisites - 
+### Prerequisites -
 
 Install [pyenv](https://github.com/pyenv/pyenv) and [poetry](https://python-poetry.org/docs/#installation)
 
@@ -145,6 +145,8 @@ the AWS, we will require this to comunicate with the docker containers:
         aws configure
       ```
 
+In order to create a bucket you can just run the tests to verify everithing is working properly and it will be created automatically.
+
 ### Nice to Have
 
 Well, hello there! If you are looking for automation, you have come to the right place!
@@ -220,7 +222,7 @@ classDiagram
       +Picture profile_picture
       +DateTime profile_picture_updated_at
       +String user_handle
-      
+
     }
     class Picture{
       +User User
@@ -257,7 +259,7 @@ classDiagram
         +DateTime submission_date
         +User votes
     }
-    
+
 ``````
 
 ## FAQ
@@ -295,4 +297,3 @@ brew remove gdal
 ```bash
 brew install gdal
 ```
-

--- a/integrations/aws/s3.py
+++ b/integrations/aws/s3.py
@@ -12,16 +12,18 @@ class Client:
         bucket_name=settings.AWS_STORAGE_BUCKET_NAME,
         location=settings.AWS_DEFAULT_REGION,
     ):
-        try:
-            self.head_bucket(bucket_name)
-        except botocore.exceptions.ClientError:
+        if not self.check_bucket_existence(bucket_name):
             return self.s3.create_bucket(
                 Bucket=bucket_name,
                 CreateBucketConfiguration={"LocationConstraint": location},
             )
 
-    def head_bucket(self, bucket_name):
-        return self.s3.head_bucket(Bucket=bucket_name)
+    def check_bucket_existence(self, bucket_name):
+        try:
+            self.s3.head_bucket(Bucket=bucket_name)
+            return True
+        except botocore.exceptions.ClientError:
+            return False
 
     def delete_bucket(self, bucket_name):
         return self.s3.delete_bucket(Bucket=bucket_name)

--- a/integrations/aws/s3.py
+++ b/integrations/aws/s3.py
@@ -11,10 +11,13 @@ class Client:
         bucket_name=settings.AWS_STORAGE_BUCKET_NAME,
         location=settings.AWS_DEFAULT_REGION,
     ):
-        return self.s3.create_bucket(
-            Bucket=bucket_name,
-            CreateBucketConfiguration={"LocationConstraint": location},
-        )
+        bucket_list = self.s3.list_buckets()
+        bucket_list_names = [bucket["Name"] for bucket in bucket_list["Buckets"]]
+        if bucket_name not in bucket_list_names:
+            return self.s3.create_bucket(
+                Bucket=bucket_name,
+                CreateBucketConfiguration={"LocationConstraint": location},
+            )
 
     def list_bucket(self):
         return self.s3.list_buckets()

--- a/integrations/aws/s3.py
+++ b/integrations/aws/s3.py
@@ -1,4 +1,5 @@
 import boto3
+import botocore
 from django.conf import settings
 
 
@@ -11,13 +12,19 @@ class Client:
         bucket_name=settings.AWS_STORAGE_BUCKET_NAME,
         location=settings.AWS_DEFAULT_REGION,
     ):
-        bucket_list = self.s3.list_buckets()
-        bucket_list_names = [bucket["Name"] for bucket in bucket_list["Buckets"]]
-        if bucket_name not in bucket_list_names:
+        try:
+            self.head_bucket(bucket_name)
+        except botocore.exceptions.ClientError:
             return self.s3.create_bucket(
                 Bucket=bucket_name,
                 CreateBucketConfiguration={"LocationConstraint": location},
             )
+
+    def head_bucket(self, bucket_name):
+        return self.s3.head_bucket(Bucket=bucket_name)
+
+    def delete_bucket(self, bucket_name):
+        return self.s3.delete_bucket(Bucket=bucket_name)
 
     def list_bucket(self):
         return self.s3.list_buckets()

--- a/photo/tests/__init__.py
+++ b/photo/tests/__init__.py
@@ -1,0 +1,4 @@
+from integrations.aws.s3 import Client
+
+client = Client()
+client.create_bucket()

--- a/photo/tests/test_database/test_picture.py
+++ b/photo/tests/test_database/test_picture.py
@@ -44,7 +44,6 @@ class PictureUploadTest(TestCase):
             "test_image.jpg", image_bytes.getvalue(), content_type="image/jpeg"
         )
         self.client = Client()
-        self.client.create_bucket()
 
     def test_upload(self):
         user = UserFactory()

--- a/photo/tests/test_s3_client/test_s3_client.py
+++ b/photo/tests/test_s3_client/test_s3_client.py
@@ -1,4 +1,3 @@
-import botocore
 from django.test import TestCase
 
 from integrations.aws.s3 import Client
@@ -9,15 +8,29 @@ class S3BucketTest(TestCase):
         self.client = Client()
         return super().setUp()
 
-    def test_s3(self):
+    def test_create(self):
         response_create = self.client.create_bucket(bucket_name="test")
         self.assertEqual(response_create["ResponseMetadata"]["HTTPStatusCode"], 200)
 
-        response_head = self.client.head_bucket(bucket_name="test")
-        self.assertEqual(response_head["ResponseMetadata"]["HTTPStatusCode"], 200)
+    def test_bucket_exists(self):
+        self.client.create_bucket(bucket_name="test-existence")
+        exists = self.client.check_bucket_existence(bucket_name="test-existence")
+        not_exists = self.client.check_bucket_existence(bucket_name="not_existence")
 
-        response_delete = self.client.delete_bucket(bucket_name="test")
+        self.assertEqual(exists, True)
+        self.assertEqual(not_exists, False)
+
+    def test_bucket_delete(self):
+        self.client.create_bucket(bucket_name="test-delete")
+        response_delete = self.client.delete_bucket(bucket_name="test-delete")
+        bucket_exists = self.client.check_bucket_existence(bucket_name="test-delete")
+
         self.assertEqual(response_delete["ResponseMetadata"]["HTTPStatusCode"], 204)
+        self.assertEqual(bucket_exists, False)
 
-        with self.assertRaises(botocore.exceptions.ClientError):
-            self.client.head_bucket(bucket_name="test")
+    def tearDown(self) -> None:
+        if self.client.check_bucket_existence("test"):
+            self.client.delete_bucket(bucket_name="test")
+        if self.client.check_bucket_existence("test-existence"):
+            self.client.delete_bucket(bucket_name="test-existence")
+        return super().tearDown()

--- a/photo/tests/test_s3_client/test_s3_client.py
+++ b/photo/tests/test_s3_client/test_s3_client.py
@@ -1,0 +1,23 @@
+import botocore
+from django.test import TestCase
+
+from integrations.aws.s3 import Client
+
+
+class S3BucketTest(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        return super().setUp()
+
+    def test_s3(self):
+        response_create = self.client.create_bucket(bucket_name="test")
+        self.assertEqual(response_create["ResponseMetadata"]["HTTPStatusCode"], 200)
+
+        response_head = self.client.head_bucket(bucket_name="test")
+        self.assertEqual(response_head["ResponseMetadata"]["HTTPStatusCode"], 200)
+
+        response_delete = self.client.delete_bucket(bucket_name="test")
+        self.assertEqual(response_delete["ResponseMetadata"]["HTTPStatusCode"], 204)
+
+        with self.assertRaises(botocore.exceptions.ClientError):
+            self.client.head_bucket(bucket_name="test")


### PR DESCRIPTION
- create_bucket verifies the existence of a bucket with the same name
The bug was generated because the s3.crete_bucket() operation is idempotent only when the location is the default US location. In all other locations returns a BucketAlreadyExistsException

- the create_bucket is called on the tests folder __init__ 
The developer does not need to perform any specific action just run the tests

closes #74 