### PR TITLE
Fix issue #190: [Claude] User model custom manager

### DIFF
--- a/photo/models.py
+++ b/photo/models.py
@@ -23,6 +23,15 @@ from photo.storages_backend import PublicMediaStorage, picture_path
 from utils.enums import ContestInternalStates
 
 
+class NamedUserManager(models.Manager):
+    def get_queryset(self):
+        return super().get_queryset().exclude(
+            models.Q(name_first__isnull=True) |
+            models.Q(name_first="") |
+            models.Q(name_last__isnull=True) |
+            models.Q(name_last="")
+        )
+
 class UserManager(BaseUserManager):
     def create_user(self, email, password=None, **kwargs):
         if not email:
@@ -84,6 +93,7 @@ class User(AbstractUser, SoftDeleteModel):
     EMAIL_FIELD = "email"
     REQUIRED_FIELDS = ["first_name", "last_name"]
     objects = UserManager()
+    named_users = NamedUserManager()
 
     class Meta:
         constraints = [

--- a/photo/tests/test_database/test_user_manager.py
+++ b/photo/tests/test_database/test_user_manager.py
@@ -1,0 +1,53 @@
+import pytest
+from django.test import TestCase
+
+from photo.models import User
+
+
+class TestNamedUserManager(TestCase):
+    def setUp(self):
+        # Create users with different name combinations
+        self.user1 = User.objects.create_user(
+            email="user1@example.com",
+            password="password123",
+            name_first="John",
+            name_last="Doe"
+        )
+        self.user2 = User.objects.create_user(
+            email="user2@example.com",
+            password="password123",
+            name_first="",
+            name_last="Smith"
+        )
+        self.user3 = User.objects.create_user(
+            email="user3@example.com",
+            password="password123",
+            name_first="Jane",
+            name_last=""
+        )
+        self.user4 = User.objects.create_user(
+            email="user4@example.com",
+            password="password123",
+            name_first=None,
+            name_last=None
+        )
+
+    def test_named_users_manager(self):
+        # Get all named users
+        named_users = User.named_users.all()
+
+        # Should only include users with both first and last names
+        self.assertEqual(named_users.count(), 1)
+        self.assertIn(self.user1, named_users)
+        self.assertNotIn(self.user2, named_users)
+        self.assertNotIn(self.user3, named_users)
+        self.assertNotIn(self.user4, named_users)
+
+    def test_default_manager_unchanged(self):
+        # Verify that the default manager still returns all users
+        all_users = User.objects.all()
+        self.assertEqual(all_users.count(), 4)
+        self.assertIn(self.user1, all_users)
+        self.assertIn(self.user2, all_users)
+        self.assertIn(self.user3, all_users)
+        self.assertIn(self.user4, all_users)


### PR DESCRIPTION
This pull request fixes #190.

The issue has been successfully resolved based on the following implemented changes and their effects:

1. A custom `NamedUserManager` was correctly implemented that filters users based on non-empty name_first and name_last fields using proper Django query filters (excluding null and empty strings).

2. The manager was properly added to the User model as `named_users` while preserving the default `objects` manager, allowing both filtering methods to coexist without interference.

3. Comprehensive tests were added that:
   - Verify the named_users manager correctly returns only users with both names populated (test_named_users_manager)
   - Confirm the default manager still returns all users (test_default_manager_unchanged)
   - Include test cases for all relevant scenarios (null names, empty strings, populated names)

4. The implementation follows Django best practices by:
   - Properly extending models.Manager
   - Using appropriate query filtering (models.Q objects)
   - Maintaining existing functionality while adding new features

The changes directly address all requirements from the issue description and the tests demonstrate that both the new functionality works as intended and existing functionality remains unchanged. The code is properly structured and follows Django conventions for custom managers.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌